### PR TITLE
fix: remove unnecessary padding from the icon

### DIFF
--- a/activity/activity.svg
+++ b/activity/activity.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
 	<!ENTITY stroke_color "#000">
 	<!ENTITY fill_color "#eee">
-]><svg height="55px" viewBox="0 0 45 45" width="55px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.5" stroke="&stroke_color;" fill="&fill_color;">
+]><svg height="55px" viewBox="0 0 42 42" width="55px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.5" stroke="&stroke_color;" fill="&fill_color;">
  <g fill="none" font-family="Times New Roman" font-size="16" id="Document" stroke="black" transform="scale(1 -1)">
   <g id="Spread" transform="translate(0 -41.25)">
    <g id="Page background">


### PR DESCRIPTION
 Removed unnecessary padding on the right and bottom sides of the activity icon. 